### PR TITLE
Add limit to Book title length

### DIFF
--- a/wbooks-api/db/migrate/20190405175406_change_title_on_books.rb
+++ b/wbooks-api/db/migrate/20190405175406_change_title_on_books.rb
@@ -1,0 +1,18 @@
+class ChangeTitleOnBooks < ActiveRecord::Migration[5.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        Book.where('length(title) > 25').each do |book|
+          book.title = "#{book.title[0..21]}..."
+          book.save!
+        end
+
+        change_column :books, :title, :string, limit: 25
+      end
+
+      dir.down do
+        change_column :books, :title, :string, limit: nil
+      end
+    end
+  end
+end

--- a/wbooks-api/db/migrate/20190405175406_change_title_on_books.rb
+++ b/wbooks-api/db/migrate/20190405175406_change_title_on_books.rb
@@ -2,7 +2,7 @@ class ChangeTitleOnBooks < ActiveRecord::Migration[5.1]
   def change
     reversible do |dir|
       dir.up do
-        Book.where('length(title) > 25').each do |book|
+        Book.where('length(title) > 25').find_each do |book|
           book.title = "#{book.title[0..21]}..."
           book.save!
         end

--- a/wbooks-api/db/schema.rb
+++ b/wbooks-api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190403191354) do
+ActiveRecord::Schema.define(version: 20190405175406) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 20190403191354) do
   create_table "books", force: :cascade do |t|
     t.string "genre", null: false
     t.string "author", null: false
-    t.string "title", null: false
+    t.string "title", limit: 25, null: false
     t.bigint "image_id", null: false
     t.string "publisher", null: false
     t.string "year", null: false

--- a/wbooks-api/spec/factories/books.rb
+++ b/wbooks-api/spec/factories/books.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     genre { Faker::Book.genre }
     author { Faker::Book.author }
     image
-    title { Faker::Book.title }
+    title { Faker::Book.title[0..24] }
     publisher { Faker::Book.publisher }
     year { Faker::Date.birthday.year }
 


### PR DESCRIPTION
### Summary

- Add limit of 25 characters to Book title length, also modify existing book titles larger than 25 characters to reflect this change.

### Trello Card

https://trello.com/c/A3OW78js/44-migraciones-opcional